### PR TITLE
Make `autoreconf` work.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,7 +149,7 @@ fi
 AC_SUBST([AM_CFLAGS])
 
 AC_CONFIG_FILES([
-        jansson.pc
+        bosjansson.pc
         Makefile
         doc/Makefile
         src/Makefile


### PR DESCRIPTION
After the fork, `jansson.pc.in` was renamed to `bosjansson.pc.in`, but not in this script, so this causes the `autoreconf` to fail.